### PR TITLE
 IE　SCRIPT1028 error

### DIFF
--- a/acbox/jquery.ajaxComboBox.6.3.js
+++ b/acbox/jquery.ajaxComboBox.6.3.js
@@ -384,7 +384,7 @@ MIT License
 						button    : 'ac_button', //ボタンのCSSクラス
 						btn_on    : 'ac_btn_on', //ボタン(mover時)
 						btn_out   : 'ac_btn_out', //ボタン(mout時)
-						input     : 'ac_input', //テキストボックス
+						input     : 'ac_input' //テキストボックス
 					});
 					break;
 


### PR DESCRIPTION
IE9互換モードのIE7でSCRIPT1028が発生していました。387行目で、オブジェクトのプロパティの最終の値の定義にカンマが入っていましたので除去しました。
